### PR TITLE
Add a dependency on ros_environment

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
+  <depend>ros_environment</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
This should resolve the build issues which are failing due to $ROS_DISTRO not being set on the buildfarm.