### PR TITLE
[ROS2 Galactic] Fix CMakeLists error at line 25 and 52

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,7 @@ else()
   set(ROS_DISTRO $ENV{ROS_DISTRO})
 endif()
 
-if(${ROS_DISTRO} MATCHES "ardent" OR ${ROS_DISTRO} MATCHES "bouncy" OR
-   ${ROS_DISTRO} MATCHES "crystal")
+if((${ROS_DISTRO} MATCHES "ardent") OR (${ROS_DISTRO} MATCHES "bouncy") OR (${ROS_DISTRO} MATCHES "crystal"))
   find_package(rosidl_generator_dds_idl REQUIRED)
 endif()
 
@@ -49,8 +48,7 @@ if(NOT "${PX4_MSGS}" STREQUAL "")
 
   # Generate Fast RTPS IDL files (previous to Dashing, so to make the IDL
   # compatible with the upstream PX4 IDL generator)
-  if(${ROS_DISTRO} MATCHES "ardent" OR ${ROS_DISTRO} MATCHES "bouncy" OR
-     ${ROS_DISTRO} MATCHES "crystal")
+  if((${ROS_DISTRO} MATCHES "ardent") OR (${ROS_DISTRO} MATCHES "bouncy") OR (${ROS_DISTRO} MATCHES "crystal"))
     rosidl_generate_dds_interfaces(${PROJECT_NAME}__fastrtps_idl
                                    IDL_FILES
                                    ${ROS_MSG_DIR_LIST}


### PR DESCRIPTION
`ROS2 Galactic and Ubuntu 20.04`

### Usage: 

```
sumedh@starfleeet:~/px4_ros_com_ros2/src/px4_ros_com/scripts$ bash build_ros2_workspace.bash 
openjdk version "13.0.7" 2021-04-20
OpenJDK Runtime Environment (build 13.0.7+5-Ubuntu-0ubuntu120.04)
OpenJDK 64-Bit Server VM (build 13.0.7+5-Ubuntu-0ubuntu120.04, mixed mode)
[0.128s] WARNING:colcon.colcon_core.package_selection:ignoring unknown package 'ros1_bridge' in --packages-skip
Starting >>> px4_msgs
--- stderr: px4_msgs                         
CMake Error at CMakeLists.txt:25 (if):
  if given arguments:

    "MATCHES" "ardent" "OR" "MATCHES" "bouncy" "OR" "MATCHES" "crystal"

  Unknown arguments specified


---
Failed   <<< px4_msgs [0.19s, exited with code 1]
                                
Summary: 0 packages finished [0.32s]
  1 package failed: px4_msgs
  1 package had stderr output: px4_msgs
  1 package not processed
ROS_DISTRO was set to 'foxy' before. Please make sure that the environment does not mix paths from different distributions.

ROS2 workspace ready...

```

### Fix:

Changed line number 25 and 52 to 
`  if((${ROS_DISTRO} MATCHES "ardent") OR (${ROS_DISTRO} MATCHES "bouncy") OR (${ROS_DISTRO} MATCHES "crystal"))`


### Output after Fix:
```
sumedh@starfleeet:~/px4_ros_com_ros2/src/px4_ros_com/scripts$ bash build_ros2_workspace.bash 
openjdk version "13.0.7" 2021-04-20
OpenJDK Runtime Environment (build 13.0.7+5-Ubuntu-0ubuntu120.04)
OpenJDK 64-Bit Server VM (build 13.0.7+5-Ubuntu-0ubuntu120.04, mixed mode)
[0.128s] WARNING:colcon.colcon_core.package_selection:ignoring unknown package 'ros1_bridge' in --packages-skip
Starting >>> px4_msgs
[Processing: px4_msgs]                             
[Processing: px4_msgs]                                     
[Processing: px4_msgs]                                       
[Processing: px4_msgs]                                       
[Processing: px4_msgs]                                        
Finished <<< px4_msgs [2min 37s] 
```