### PR TITLE
fixed vtol vehicle status 

### DIFF
--- a/msg/VtolVehicleStatus.msg
+++ b/msg/VtolVehicleStatus.msg
@@ -7,6 +7,8 @@ uint8 VEHICLE_VTOL_STATE_FW = 4
 
 uint64 timestamp			# time since system start (microseconds)
 
-uint8 vehicle_vtol_state		# current state of the vtol, see VEHICLE_VTOL_STATE
-
+bool vtol_in_rw_mode			# true: vtol vehicle is in rotating wing mode
+bool vtol_in_trans_mode
+bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
 bool vtol_transition_failsafe		# vtol in transition failsafe mode
+bool fw_permanent_stab			# In fw mode stabilize attitude even if in manual mode


### PR DESCRIPTION
fixed vtol vehicle status  to be consistent with what is being published by px4 firmware at the stable version `1.13.2`