### PR TITLE
Fix README for ROS 2 message generation for versioned messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,11 @@ find_package(rosidl_default_generators REQUIRED)
 
 # get all msg files
 set(MSGS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/msg")
-file(GLOB PX4_MSGS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${MSGS_DIR}/*.msg" "${MSGS_DIR}/versioned/*.msg")
+file(GLOB PX4_MSGS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${MSGS_DIR}/*.msg")
 
 # get all srv files
 set(SRVS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/srv")
-file(GLOB PX4_SRVS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${SRVS_DIR}/*.srv" "${SRVS_DIR}/versioned/*.msg")
+file(GLOB PX4_SRVS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${SRVS_DIR}/*.srv")
 
 # Generate introspection typesupport for C and C++ and IDL files
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ However, if you are using a custom PX4 version and you modified existing message
 - Copy all `*.msg` and  `*.srv` files from `PX4-Autopilot/msg/` and `PX4-Autopilot/srv/` in  `msg/` and  `srv/`, respectively. Assuming that this repository and the PX4-Autopilot repository are placed in your home folder, you can run:
   ```sh
   rm -f ~/px4_msgs/msg/*.msg
-  rm -f ~/px4_msgs/msg/versioned/*.msg
   rm -f ~/px4_msgs/srv/*.srv
   cp ~/PX4-Autopilot/msg/*.msg ~/px4_msgs/msg/
-  cp ~/PX4-Autopilot/msg/versioned/*.msg ~/px4_msgs/msg/versioned/
+  cp ~/PX4-Autopilot/msg/versioned/*.msg ~/px4_msgs/msg/
   cp ~/PX4-Autopilot/srv/*.srv ~/px4_msgs/srv/
   ```
+**Note:** The ROS 2 message generation pipeline requires all messages to be directly under `msg/` and doesn't support sub-directories.
 
 ## Install, build and usage
 


### PR DESCRIPTION
It looks like rosidl doesn't support sub-directories https://github.com/ros2/rosidl/issues/213
The new instructions mention to copy the messages from the PX4 repo into `px4_msgs` inside of `msg/versioned` but this silently breaks when building for me.

The only indication I had was that `px4-ros2-interface-lib` was giving me errors like:
```
Failed to open install/px4_msgs/share/px4_msgs/msg/ActuatorMotors.msg
```

Copying all messages at the root of `msg/` fixes it. We should however be careful to never have duplicated messages between the ones in `msg/` and `msg/versioned/`