### PR TITLE
fix: Raise minimum CMake version to v3.5 for `ros1` branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(px4_msgs)
 


### PR DESCRIPTION
Raise the minimum required `CMake` version from `v2.8.3` to `v3.5` to support building with recent `CMake` versions (`v4+`).

This PR aligns the `CMake` version requirements with the other release branches.