### PR TITLE
cmake: drop ADD_LINTER_TESTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 	${PX4_MSGS}
 	${PX4_SRVS}
 	DEPENDENCIES builtin_interfaces
-	ADD_LINTER_TESTS
 )
 
 ament_export_dependencies(rosidl_default_runtime)


### PR DESCRIPTION
fix compilation performance issues discussed in https://github.com/PX4/px4_msgs/issues/41