### PR TITLE
chore: adopt standard ROS 2 build-farm best practices

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+build/
+install/
+log/
+CMakeCache.txt
+CMakeFiles/
+.colcon/
+*.egg-info
+.debbuild/
+.obj-*
+debian/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for px4_msgs
+# These owners are requested for review on pull requests that touch matching paths.
+# See https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repo
+*       @TSC21 @beniaminopozzan
+
+# Repository infrastructure
+/.github/   @TSC21 @beniaminopozzan
+/CMakeLists.txt @TSC21 @beniaminopozzan
+/package.xml    @TSC21 @beniaminopozzan

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Report a problem with the px4_msgs package (build, packaging, CI, docs)
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report!
+
+        **Note:** The message and service definitions (`*.msg` / `*.srv`) are
+        generated automatically from PX4-Autopilot. If a *field* or *message*
+        is wrong or missing, please open the issue against
+        [PX4-Autopilot](https://github.com/PX4/PX4-Autopilot/issues) instead.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce the behavior (commands, branch, etc.).
+      placeholder: |
+        1. Checkout branch '...'
+        2. Run `colcon build --packages-select px4_msgs`
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+  - type: input
+    id: ros-distro
+    attributes:
+      label: ROS 2 distribution
+      placeholder: "e.g. Humble, Jazzy, Kilted, Rolling"
+    validations:
+      required: true
+  - type: input
+    id: px4-branch
+    attributes:
+      label: px4_msgs branch / PX4 version
+      placeholder: "e.g. main, release/1.17"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "e.g. Ubuntu 24.04"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      description: Paste any relevant build or runtime logs. This will be rendered as code.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Message / service definition changes
+    url: https://github.com/PX4/PX4-Autopilot/issues
+    about: The *.msg and *.srv files are generated from PX4-Autopilot. Report field or message changes there.
+  - name: PX4 Discord (questions & troubleshooting)
+    url: https://discord.gg/dronecode
+    about: Ask usage questions and reach the PX4 development team.
+  - name: PX4 ROS 2 User Guide
+    url: https://docs.px4.io/main/en/ros/ros2_comm.html
+    about: Documentation on using px4_msgs to communicate with PX4 over ROS 2.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest an improvement to the px4_msgs package infrastructure
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement!
+
+        **Note:** New or changed *message / service fields* must be proposed
+        against [PX4-Autopilot](https://github.com/PX4/PX4-Autopilot/issues),
+        since the definitions here are generated and synchronized from there.
+        Use this form for changes to the packaging, build, CI, or docs.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of the problem, e.g. "I'm always frustrated when [...]"
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: Any alternative solutions or features you've considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+Thanks for contributing to px4_msgs!
+
+NOTE: Message and service definitions (the *.msg and *.srv files) are generated automatically from the uORB definitions in PX4-Autopilot and are synchronized by CI. Do **not** edit them directly here — submit those changes to https://github.com/PX4/PX4-Autopilot instead. See CONTRIBUTING.md.
+
+This template is for changes to the repository infrastructure (CMake, packaging, CI, documentation, etc.).
+-->
+
+## Description
+
+<!-- Describe your changes in detail. What problem does this PR solve? -->
+
+## Type of change
+
+<!-- Put an `x` in the boxes that apply. -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing behavior to change)
+- [ ] Build / CI / packaging change
+- [ ] Documentation update
+
+## Related issues
+
+<!-- Link any related issues, e.g. "Fixes #123" or "Relates to #123". -->
+
+## Checklist
+
+- [ ] My changes do not edit the auto-generated `*.msg` / `*.srv` definitions (those go to [PX4-Autopilot](https://github.com/PX4/PX4-Autopilot)).
+- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.
+- [ ] I have updated the [CHANGELOG.rst](../CHANGELOG.rst) if appropriate.
+- [ ] CI passes (`colcon build` / `colcon test`) on the affected branch.
+- [ ] My commits are signed off (`git commit -s`, DCO).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,9 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,40 +1,276 @@
 name: Build package
 
-# CI runs over all branches that do not contain 'ros1' in the name
+# Push builds run on the integration branches; everything else (topic branches)
+# is covered by the pull_request trigger, so a PR does not run twice per commit.
 on:
   push:
+    branches:
+      - main
+      - 'release/**'
+  pull_request:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  focal:
-    name: "Build on Ubuntu Focal"
-    runs-on: ubuntu-20.04
+  build:
+    name: "Build & test (${{ matrix.ros2_distro }} / Ubuntu)"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each maintained ROS 2 distribution on its REP-2000 Ubuntu. Lyrical
+        # (Ubuntu 26.04) has no GitHub runner yet and is built in a container in
+        # the build-lyrical job below.
+        include:
+          - ros2_distro: humble
+            os: ubuntu-22.04
+          - ros2_distro: jazzy
+            os: ubuntu-24.04
+          - ros2_distro: kilted
+            os: ubuntu-24.04
+          - ros2_distro: rolling
+            os: ubuntu-24.04
+    env:
+      # Compile the generated message sources through ccache (restored below).
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
     steps:
-      - uses: actions/checkout@v4
-      - uses: ros-tooling/setup-ros@v0.6
+      - uses: actions/checkout@v5
+      - name: Restore ccache
+        uses: actions/cache@v5
         with:
-          required-ros-distributions: foxy
-      - uses: ros-tooling/action-ros-ci@v0.3
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-${{ matrix.ros2_distro }}-${{ github.run_id }}
+          restore-keys: ccache-${{ matrix.ros2_distro }}-
+      # Enable ccache through its compiler masquerade (/usr/lib/ccache, populated
+      # when ccache is installed with the deps below). We deliberately do NOT set
+      # CMAKE_<LANG>_COMPILER_LAUNCHER: the runners already put /usr/lib/ccache on
+      # PATH, so a launcher on top double-wraps the compiler (ccache invoking
+      # ccache) and intermittently breaks CMake's compiler check.
+      - name: Enable ccache compiler masquerade
+        run: echo "/usr/lib/ccache" >> "$GITHUB_PATH"
+      # Reduce apt flakiness: the GitHub runners run background apt/unattended
+      # upgrades that hold the dpkg/apt locks, which intermittently makes
+      # setup-ros's apt step fail ("Unable to lock /var/lib/apt/lists/") and
+      # leaves ROS partially installed (later "No module named ament_package /
+      # rosidl_adapter / ament_cmake_test"). Stop those services, wait for the
+      # locks, and make apt retry transient mirror errors.
+      - name: Free apt and enable retries
+        run: |
+          sudo tee /etc/apt/apt.conf.d/80-ci-retries >/dev/null <<'EOF'
+          Acquire::Retries "5";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          EOF
+          sudo systemctl stop apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true
+          sudo systemctl stop unattended-upgrades.service apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+          sudo systemctl kill --kill-who=all apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+          for _ in $(seq 1 60); do
+            if ! sudo fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend >/dev/null 2>&1; then
+              break
+            fi
+            sleep 2
+          done
+      # setup-ros and action-ros-ci are retried to absorb transient
+      # infrastructure failures (ros-apt-source GitHub-API 404s, apt mirror
+      # hiccups, and randomly incomplete installs), which otherwise need a
+      # manual job re-run.
+      #
+      # setup-ros is run *without* required-ros-distributions: that input
+      # installs the whole ros-<distro>-desktop (rviz, Qt, ...), which is huge
+      # and pointless for an interface package. Instead it only sets up the ROS
+      # apt source + ros-dev-tools, and action-ros-ci's rosdep step below pulls
+      # just px4_msgs's actual dependencies — much faster.
+      - name: Setup ROS 2 (retried)
+        uses: Wandalen/wretry.action@v3
+        with:
+          attempt_limit: 3
+          attempt_delay: 15000
+          action: ros-tooling/setup-ros@v0.7
+      # Install px4_msgs's exact build/test dependencies directly by apt package
+      # name, rather than relying on action-ros-ci's rosdep resolution. This is
+      # what keeps the lean install (no desktop) reliable and fast: it avoids
+      # both the intermittent "No module named ament_cmake_test" incomplete
+      # installs and rosdep key-resolution gaps (e.g. rosidl_default_generators
+      # not resolving on Noble for Rolling). rmw-fastrtps-cpp pulls a concrete
+      # typesupport implementation, without which rosidl's get_used_typesupports
+      # fails at configure time ("No 'rosidl_typesupport_c' found"). Idempotent,
+      # with retries.
+      - name: Ensure px4_msgs build and test dependencies
+        run: |
+          d="${{ matrix.ros2_distro }}"
+          for _ in 1 2 3; do
+            sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+              ccache \
+              "ros-${d}-ament-cmake" \
+              "ros-${d}-rosidl-default-generators" \
+              "ros-${d}-rosidl-default-runtime" \
+              "ros-${d}-rmw-fastrtps-cpp" \
+              "ros-${d}-builtin-interfaces" \
+              "ros-${d}-ament-cmake-test" \
+              "ros-${d}-ament-lint-auto" \
+              "ros-${d}-ament-lint-common" && break
+            sleep 15
+          done
+      - name: Build and test (retried)
+        uses: Wandalen/wretry.action@v3
+        with:
+          attempt_limit: 3
+          attempt_delay: 15000
+          action: ros-tooling/action-ros-ci@v0.4
+          with: |
+            package-name: px4_msgs
+            target-ros2-distro: ${{ matrix.ros2_distro }}
+
+  # Lyrical targets Ubuntu 26.04 (resolute), for which GitHub has no runner yet,
+  # so this job runs inside the official ros:lyrical container and uses the same
+  # standard action-ros-ci tooling there.
+  build-lyrical:
+    name: "Build & test (lyrical / Ubuntu 26.04 container)"
+    runs-on: ubuntu-latest
+    container:
+      image: ros:lyrical-ros-base
+    defaults:
+      run:
+        shell: bash
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+    steps:
+      - uses: actions/checkout@v5
+      - name: Restore ccache
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-lyrical-${{ github.run_id }}
+          restore-keys: ccache-lyrical-
+      - name: Install colcon, rosdep and lint tooling
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            sudo ccache python3-colcon-common-extensions \
+            python3-colcon-lcov-result python3-colcon-coveragepy-result \
+            python3-rosdep python3-vcstool \
+            ros-lyrical-ament-cmake-test \
+            ros-lyrical-ament-lint-auto \
+            ros-lyrical-ament-lint-common
+          rosdep init 2>/dev/null || true
+          rosdep update
+          # Enable ccache via its masquerade (no COMPILER_LAUNCHER, which would
+          # double-wrap). The container has no /usr/lib/ccache on PATH by default,
+          # so add it now that ccache is installed.
+          echo "/usr/lib/ccache" >> "$GITHUB_PATH"
+      - uses: ros-tooling/action-ros-ci@v0.4
         with:
           package-name: px4_msgs
-          target-ros2-distro: foxy
-  jammy:
-    name: "Build on Ubuntu Jammy"
-    runs-on: ubuntu-22.04
+          target-ros2-distro: lyrical
+
+  build-windows:
+    name: "Build & test (${{ matrix.ros2_distro }} / Windows)"
+    # Pinned to windows-2022 on purpose: action-ros-ci@v0.4 wraps every command
+    # in `call "...\Microsoft Visual Studio\2022\Enterprise\...\vcvars64.bat"`,
+    # a hardcoded path. windows-latest has rolled to windows-2025 (Visual Studio
+    # 2026), where that path does not exist, so every action-ros-ci command fails
+    # instantly. windows-2022 ships VS 2022 Enterprise at the expected location.
+    runs-on: windows-2022
     strategy:
+      fail-fast: false
       matrix:
-        ros2_distro: [humble, rolling]
+        # Windows coverage targets Jazzy only. ros-tooling pins setuptools<60,
+        # which has no distutils on Python 3.12, so the stack must run on Python
+        # 3.11 (see setup-python below). Jazzy's Windows binaries are built for
+        # 3.11 and work; Humble's target 3.8 and Rolling's target 3.12, so
+        # neither is compatible with the 3.11 that ros-tooling requires.
+        ros2_distro: [jazzy]
     steps:
-      - uses: actions/checkout@v4
-      - uses: ros-tooling/setup-ros@v0.6
+      - uses: actions/checkout@v5
+      # Pin Python 3.11 to match Jazzy's Windows binaries and avoid ros-tooling's
+      # setuptools<60 / missing-distutils breakage on Python 3.12.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      # NOTE: not wrapped in a retry action here. wretry injects the GitHub
+      # context as INPUT_GITHUB_CONTEXT, which exceeds the Windows environment
+      # variable length limit and breaks setup-ros's chocolatey installs.
+      - uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros2_distro }}
-      - uses: ros-tooling/action-ros-ci@v0.3
+      - uses: ros-tooling/action-ros-ci@v0.4
         with:
           package-name: px4_msgs
           target-ros2-distro: ${{ matrix.ros2_distro }}
+
+  # ROS 2 no longer publishes macOS Homebrew bottles, so macOS is built via
+  # RoboStack (ROS 2 packaged on conda-forge), which provides binaries for
+  # osx-arm64 and osx-64. RoboStack only ships released distros for macOS, so
+  # this targets Jazzy.
+  build-macos:
+    name: "Build & test (jazzy / macOS, RoboStack)"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-15-intel]
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: src/px4_msgs
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: ros_jazzy
+          # Cache the solved/downloaded conda environment so re-runs skip the
+          # (slow) solve + download of ros-jazzy-ros-base.
+          cache-environment: true
+          cache-downloads: true
+          condarc: |
+            channels:
+              - conda-forge
+              - robostack-jazzy
+          create-args: >-
+            python=3.11
+            ros-jazzy-ros-base
+            ros-jazzy-ament-cmake
+            ros-jazzy-rosidl-default-generators
+            ros-jazzy-builtin-interfaces
+            ros-jazzy-ament-lint-auto
+            ros-jazzy-ament-lint-common
+            colcon-common-extensions
+            cmake
+            ninja
+            c-compiler
+            cxx-compiler
+      - name: Build
+        run: colcon build --packages-select px4_msgs --event-handlers console_cohesion+
+      - name: Test
+        # The ament_xmllint linter validates package.xml against the schema at
+        # http://download.ros.org/schema/package_format3.xsd, but conda-forge's
+        # libxml2 is built without HTTP support, so the fetch always fails with
+        # "No such file or directory". This linter is therefore unsupported on
+        # RoboStack/macOS and is excluded; xmllint still runs on the Ubuntu jobs.
+        run: colcon test --packages-select px4_msgs --event-handlers console_cohesion+ --return-code-on-test-failure --ctest-args -E xmllint
+
+  pre-commit:
+    name: "Lint (pre-commit)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      # Cache the installed pre-commit hook environments (node/python/go tools)
+      # so they are not reinstalled on every run.
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,92 @@
+name: Create GitHub release
+
+# Turns the message-sync activity coming from the upstream PX4 bot into a
+# GitHub release, which in turn drives the packaging (.deb) and rosdistro
+# (bloom) release workflows.
+#
+# Triggers:
+#   * a version tag `vX.Y.Z` is pushed, or
+#   * a `release/**` branch is pushed and its package.xml version does not yet
+#     have a matching `vX.Y.Z` tag (i.e. the release line was just bumped).
+#
+# NOTE: to let the published release cascade into the `Package (.deb)` and
+# `Release to rosdistro (bloom)` workflows, set a `RELEASE_TOKEN` secret to a
+# PAT. Releases created with the default GITHUB_TOKEN do not trigger further
+# workflows. If `RELEASE_TOKEN` is absent the release is still created with the
+# default token (without the cascade).
+on:
+  push:
+    branches:
+      - 'release/**'
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Determine release tag
+        id: ver
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            tag="${GITHUB_REF#refs/tags/}"
+          else
+            version="$(sed -n 's:.*<version>\(.*\)</version>.*:\1:p' package.xml | head -n1)"
+            if [ -z "${version}" ]; then
+              echo "Could not read version from package.xml" >&2
+              exit 1
+            fi
+            tag="v${version}"
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Release tag: ${tag}"
+
+      - name: Skip if release already exists
+        id: exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ steps.ver.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Release ${{ steps.ver.outputs.tag }} already exists; nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag for release branch bump
+        if: steps.exists.outputs.skip == 'false' && startsWith(github.ref, 'refs/heads/')
+        run: |
+          tag="${{ steps.ver.outputs.tag }}"
+          if ! git rev-parse "${tag}" >/dev/null 2>&1; then
+            git tag "${tag}"
+            git push origin "${tag}"
+          fi
+
+      - name: Generate release notes from message diff
+        if: steps.exists.outputs.skip == 'false'
+        run: |
+          tag="${{ steps.ver.outputs.tag }}"
+          ./scripts/generate_release_notes.sh "${tag}" > notes.md || true
+          if [ ! -s notes.md ]; then
+            echo "Automated release of px4_msgs ${tag}." > notes.md
+          fi
+
+      - name: Create GitHub release
+        if: steps.exists.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
+        run: |
+          tag="${{ steps.ver.outputs.tag }}"
+          gh release create "${tag}" \
+            --title "${tag}" \
+            --notes-file notes.md \
+            --target "${GITHUB_SHA}"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,73 @@
+name: Package (.deb)
+
+# Builds Debian packages of px4_msgs for amd64 and arm64 using the bundled
+# builder container (see container/Dockerfile and scripts/build_deb_host.sh).
+# Packages are uploaded as build artifacts and, on a GitHub release, attached
+# to the release. This automates the package generation step towards publishing
+# official PX4-hosted packages.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: write
+
+jobs:
+  deb:
+    name: "Build .deb (${{ matrix.ros2_distro }} / ${{ matrix.arch }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ros2_distro: [humble, jazzy, kilted, rolling, lyrical]
+        arch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the px4_msgs-builder image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: container/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros2_distro }}
+          tags: px4io/px4_msgs-builder:${{ matrix.ros2_distro }}
+          load: true
+          # Cache the builder image layers (apt/rosdep/bloom install) across runs.
+          cache-from: type=gha,scope=${{ matrix.ros2_distro }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.ros2_distro }}-${{ matrix.arch }}
+
+      - name: Build the Debian package
+        run: |
+          mkdir -p out
+          docker run --rm --platform "linux/${{ matrix.arch }}" \
+            -v "${{ github.workspace }}":/src \
+            -v "${{ github.workspace }}/out":/artifacts \
+            "px4io/px4_msgs-builder:${{ matrix.ros2_distro }}" \
+            /usr/local/bin/build.sh
+          ls -lh out/
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: px4_msgs-deb-${{ matrix.ros2_distro }}-${{ matrix.arch }}
+          path: out/*.deb
+          if-no-files-found: error
+
+      - name: Attach packages to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" out/*.deb --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release to rosdistro (bloom)
+
+# Opens a release pull request against ros/rosdistro for each supported ROS 2
+# distribution whenever a GitHub release is published, automating the recurring
+# part of releasing px4_msgs onto the ROS build farm.
+#
+# Prerequisites (one-time setup, see CONTRIBUTING.md):
+#   1. Releases use a single release repository, PX4/px4_msgs-release. A
+#      maintainer must seed a bloom track for each current distro (humble, jazzy,
+#      kilted, rolling) once with an interactive `bloom-release` (devel_branch
+#      main). That first run also adds the `release:` block for px4_msgs to
+#      ros/rosdistro (it currently has only `source:`/`doc:`). After that, this
+#      workflow automates subsequent releases. (The legacy PX4/px4_msgs2-release
+#      has been archived in favour of the single PX4/px4_msgs-release.)
+#   2. A repository secret `BLOOM_GITHUB_TOKEN` must be set to a token that can
+#      push to PX4/px4_msgs-release and open a pull request on ros/rosdistro
+#      (typically a fine-grained PAT or a bot account token).
+#
+# Until those are configured the job exits successfully without doing anything,
+# so it never blocks a release.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ros_distro:
+        description: "Single ROS 2 distribution to release (blank = all supported)"
+        required: false
+        default: ""
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  bloom-release:
+    name: "bloom-release (${{ matrix.ros2_distro }})"
+    runs-on: ubuntu-latest
+    container:
+      image: ros:rolling-ros-core
+    strategy:
+      fail-fast: false
+      matrix:
+        ros2_distro: [humble, jazzy, kilted, rolling, lyrical]
+    steps:
+      - name: Check release automation is configured
+        id: guard
+        env:
+          BLOOM_GITHUB_TOKEN: ${{ secrets.BLOOM_GITHUB_TOKEN }}
+        run: |
+          if [ -z "${BLOOM_GITHUB_TOKEN}" ]; then
+            echo "BLOOM_GITHUB_TOKEN is not set; skipping bloom release." >&2
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip distribution not requested
+        id: select
+        if: steps.guard.outputs.enabled == 'true'
+        run: |
+          requested="${{ github.event.inputs.ros_distro }}"
+          if [ -n "${requested}" ] && [ "${requested}" != "${{ matrix.ros2_distro }}" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install bloom
+        if: steps.guard.outputs.enabled == 'true' && steps.select.outputs.run == 'true'
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends python3-bloom git ca-certificates
+
+      - name: Configure git identity
+        if: steps.guard.outputs.enabled == 'true' && steps.select.outputs.run == 'true'
+        run: |
+          git config --global user.name "PX4 BuildBot"
+          git config --global user.email "bot@px4.io"
+
+      - name: Open rosdistro release pull request
+        if: steps.guard.outputs.enabled == 'true' && steps.select.outputs.run == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.BLOOM_GITHUB_TOKEN }}
+        run: |
+          # The track + the rosdistro release block must already be seeded for
+          # this distro (see header). This automates subsequent releases.
+          bloom-release \
+            --rosdistro "${{ matrix.ros2_distro }}" \
+            --track "${{ matrix.ros2_distro }}" \
+            --non-interactive \
+            px4_msgs

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build/
 msg/idl.cc
+out/
+debian/
+.ob*/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,67 @@
+# See https://pre-commit.com for more information.
+# Run `pre-commit install` to set up the git hook, or `pre-commit run --all-files`.
+#
+# NOTE: the message/service definitions (*.msg, *.srv) are generated and
+# synchronized from PX4-Autopilot, so they are excluded from formatting hooks.
+exclude: '^(msg|srv)/.*\.(msg|srv)$'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      # Whitespace / EOL hygiene.
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      # Repository hygiene.
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-symlinks
+      - id: destroyed-symlinks
+      # Scripts must have shebangs and be executable (and vice versa).
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      # Structured-file syntax: package.xml, CMake-adjacent yaml, configs.
+      - id: check-xml
+      - id: check-yaml
+      - id: check-json
+
+  # Validate the GitHub Actions workflows and the Dependabot config.
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.31.2
+    hooks:
+      - id: check-github-workflows
+      - id: check-dependabot
+
+  # Lint the shell helper scripts (containerized .deb build, generators).
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+
+  # Spell-check documentation and tooling (generated CHANGELOG is excluded).
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        # "ned" = NED frame; "ot" is a false positive from a [Bb]ot regex split.
+        args: ["--ignore-words-list=ned,ot"]
+        exclude: '^CHANGELOG\.rst$'
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.44.0
+    hooks:
+      - id: markdownlint
+        args: ["--disable", "MD013", "MD033", "MD041"]
+
+  # Build-farm gate: validate package.xml exactly as bloom/catkin_pkg does, so a
+  # manifest that would fail to release is caught before it reaches the farm.
+  - repo: local
+    hooks:
+      - id: validate-package-xml
+        name: validate package.xml (catkin_pkg)
+        entry: python3 -c "import sys; from catkin_pkg.package import parse_package; [parse_package(f).validate() for f in sys.argv[1:]]"
+        language: python
+        additional_dependencies: [catkin_pkg]
+        files: '(^|/)package\.xml$'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,77 @@
+Changelog for package px4_msgs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The version numbers of this package track the corresponding `PX4 Autopilot
+<https://github.com/PX4/PX4-Autopilot>`_ release line. The message and service
+definitions are generated and synchronized automatically from the uORB
+definitions in PX4-Autopilot, so the entries below are produced from the tagged
+release history rather than by manual edits (see
+``scripts/generate_changelog.sh``).
+
+1.17.0 (2026-03-22)
+-------------------
+* Synchronized with PX4 Autopilot 1.17.0.
+* Added: BatteryInfo, DronecanNodeStatus, FixedWingLateralGuidanceStatus, FixedWingLateralSetpoint, FixedWingLateralStatus, FixedWingLongitudinalSetpoint, FixedWingRunwayControl, LateralControlConfiguration, LongitudinalControlConfiguration, NeuralControl, RoverSpeedSetpoint, RoverSpeedStatus, SensorGnssStatus.
+* Removed: AckermannVelocitySetpoint, DifferentialVelocitySetpoint, NpfgStatus, RoverVelocityStatus.
+* Changed 44 message/service definition(s).
+* Contributors: Beniamino Pozzan
+
+1.16.2 (2025-08-07)
+-------------------
+* PX4 point release; message and service definitions identical to 1.16.1.
+* Contributors: PX4 BuildBot
+
+1.16.1 (2025-08-07)
+-------------------
+* PX4 point release; message and service definitions identical to 1.16.0.
+* Contributors: PX4 BuildBot
+
+1.16.0 (2025-08-07)
+-------------------
+* Synchronized with PX4 Autopilot 1.16.0.
+* Added: AckermannVelocitySetpoint, DifferentialVelocitySetpoint, DistanceSensorModeChangeRequest, FuelTankStatus, InternalCombustionEngineControl, NavigatorStatus, OpenDroneIdArmStatus, OpenDroneIdOperatorId, OpenDroneIdSelfId, OpenDroneIdSystem, PurePursuitStatus, RoverAttitudeSetpoint, RoverAttitudeStatus, RoverPositionSetpoint, RoverRateSetpoint, RoverRateStatus, RoverSteeringSetpoint, RoverThrottleSetpoint, RoverVelocityStatus, TrajectorySetpoint6dof.
+* Removed: Buffer128, CollisionReport, DifferentialDriveSetpoint, TrajectoryBezier, TrajectoryWaypoint, VehicleTrajectoryBezier, VehicleTrajectoryWaypoint.
+* Changed 71 message/service definition(s).
+* Contributors: Beniamino Pozzan, Claudio Chies, GuillaumeLaine, Mathieu David, PX4 BuildBot
+
+1.15.4 (2025-03-20)
+-------------------
+* PX4 point release; message and service definitions identical to 1.15.3.
+* Contributors: PX4 BuildBot
+
+1.15.3 (2025-03-20)
+-------------------
+* Synchronized with PX4 Autopilot 1.15.3.
+* Changed 3 message/service definition(s).
+* Contributors: Beniamino Pozzan
+
+1.15.2 (2024-10-06)
+-------------------
+* PX4 point release; message and service definitions identical to 1.15.1.
+* Contributors: PX4 BuildBot
+
+1.15.1 (2024-10-06)
+-------------------
+* Synchronized with PX4 Autopilot 1.15.1.
+* Changed 1 message/service definition(s).
+* Contributors: Beniamino Pozzan, PX4 BuildBot
+
+1.15.0 (2024-06-17)
+-------------------
+* Synchronized with PX4 Autopilot 1.15.0.
+* Added: ArmingCheckReply, ArmingCheckRequest, Buffer128, CanInterfaceStatus, ConfigOverrides, DatamanRequest, DatamanResponse, DifferentialDriveSetpoint, FigureEightStatus, FlightPhaseEstimation, GeofenceStatus, GotoSetpoint, GpioConfig, GpioIn, GpioOut, GpioRequest, MessageFormatRequest, MessageFormatResponse, ParameterResetRequest, ParameterSetUsedRequest, ParameterSetValueRequest, ParameterSetValueResponse, RegisterExtComponentReply, RegisterExtComponentRequest, RtlStatus, SensorAirflow, UnregisterExtComponent, VehicleCommand, VelocityLimits, WheelEncoders.
+* Changed 35 message/service definition(s).
+* Contributors: Audrow Nash, Beniamino Pozzan, dependabot[bot], Federico Ciresola, PX4 BuildBot
+
+1.14.0 (2023-11-11)
+-------------------
+* Synchronized with PX4 Autopilot 1.14.0.
+* Added: EstimatorAidSource1d, EstimatorAidSource2d, EstimatorAidSource3d, EstimatorBias3d, FailsafeFlags, FollowTargetEstimator, FollowTargetStatus, Gripper, HealthReport, LandingGearWheel, LaunchDetectionStatus, ModeCompleted, NormalizedUnsignedSetpoint, QshellReq, SensorOpticalFlow, SensorUwb, TiltrotorExtraControls, VehicleOpticalFlow, VehicleOpticalFlowVel.
+* Removed: ActuatorControls, ActuatorControls0, ActuatorControls1, ActuatorControls2, ActuatorControls3, ActuatorControlsStatus1, ActuatorControlsVirtualFw, ActuatorControlsVirtualMc, ActuatorOutputsSim, CommanderState, EstimatorAttitude, EstimatorGlobalPosition, EstimatorInnovationTestRatios, EstimatorInnovationVariances, EstimatorLocalPosition, EstimatorOdometry, EstimatorOpticalFlowVel, EstimatorVisualOdometryAligned, EstimatorWind, FwVirtualAttitudeSetpoint, GimbalV1Command, ManualControlInput, McVirtualAttitudeSetpoint, ObstacleDistanceFused, OpticalFlow, OrbTestMediumMulti, OrbTestMediumQueue, OrbTestMediumQueuePoll, OrbTestMediumWrapAround, Safety, SafetyButton, SensorsStatusBaro, SensorsStatusMag, TestMotor, Timesync, UwbDistance, UwbGrid, VehicleAngularAcceleration, VehicleAngularVelocityGroundtruth, VehicleAttitudeGroundtruth, VehicleGlobalPositionGroundtruth, VehicleGpsPosition, VehicleLocalPositionGroundtruth, VehicleMocapOdometry, VehicleStatusFlags, VehicleTrajectoryWaypointDesired, VehicleVisionAttitude, VehicleVisualOdometry, WheelEncoders.
+* Changed 72 message/service definition(s).
+* Contributors: Beniamino Pozzan, Daniel Agar, PX4 BuildBot
+
+1.13.0 (2023-07-10)
+-------------------
+* Initial tracked release, synchronized with PX4 Autopilot 1.13.0.
+* Contributors: PX4 BuildBot

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,28 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8)
 
 project(px4_msgs)
 
-list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	add_compile_options(-Wall -Wextra)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(builtin_interfaces REQUIRED)
+# rosidl_default_generators must be found before the interface dependencies so
+# the available typesupports are registered first; on newer rosidl (Rolling,
+# Kilted) finding builtin_interfaces first fails with "No 'rosidl_typesupport_c'
+# found".
 find_package(rosidl_default_generators REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 
-# ##############################################################################
-# Generate ROS messages, ROS2 interfaces and IDL files #
-# ##############################################################################
+# #############################################################################
+# Generate ROS messages, ROS 2 interfaces and IDL files
+# #############################################################################
 
 # get all msg files
 set(MSGS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/msg")
@@ -26,11 +34,20 @@ file(GLOB PX4_SRVS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${SRVS_DIR}/*.srv")
 
 # Generate introspection typesupport for C and C++ and IDL files
 rosidl_generate_interfaces(${PROJECT_NAME}
-	${PX4_MSGS}
-	${PX4_SRVS}
-	DEPENDENCIES builtin_interfaces
+  ${PX4_MSGS}
+  ${PX4_SRVS}
+  DEPENDENCIES builtin_interfaces
 )
 
 ament_export_dependencies(rosidl_default_runtime)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # The message/service definitions are generated from PX4-Autopilot and the
+  # remaining sources carry no per-file copyright headers, so skip the
+  # copyright linter (the license is declared in package.xml / LICENSE).
+  set(ament_cmake_copyright_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 ament_package()

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,24 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the `px4_msgs` community a harassment-free experience for everyone, regardless of background or identity. We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standard
+
+This project adopts the **[Contributor Covenant, version 2.1][covenant]** as its Code of Conduct. All contributors, maintainers, and participants are expected to read and abide by it. Please refer to the linked document for the full text, including examples of expected behavior, enforcement responsibilities, scope, and enforcement guidelines.
+
+As part of the wider [Dronecode][dronecode] and [ROS][ros] ecosystems, this project also aligns with their respective community guidelines.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project maintainers listed in [`package.xml`](package.xml), or raised with the PX4 development team on the [PX4 Discord server][discord]. All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][covenant], version 2.1.
+
+[covenant]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+[dronecode]: https://dronecode.org/
+[ros]: https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Code-Of-Conduct.html
+[discord]: https://discord.gg/dronecode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,59 @@
 # Contributing
 
-*Do not* commit changes directly to this repository that change the message definitions. All the message definitions are directly generated from the [uORB msg definitions](https://github.com/PX4/Firmware/tree/master/msg) on the [PX4 Firmware repository](https://github.com/PX4/Firmware). Any fixes or improvements one finds suitable to apply to the message definitions should be directly done on the uORB message files. The deployment of these are taken care by a Jenkins CI/CD stage.
+Thanks for your interest in contributing to `px4_msgs`!
 
-### Contributing to the PX4 Firmware repository (or to this repository, not including message definitions)
+## Message and service definitions are auto-generated
 
-Follow the [`Contributing` guide](https://github.com/PX4/Firmware/blob/master/CONTRIBUTING.md) from the PX4 Firmware repo.
+**Do not** commit changes directly to this repository that modify the message or service definitions. All `*.msg` and `*.srv` files are generated from the [uORB message definitions](https://github.com/PX4/PX4-Autopilot/tree/main/msg) in the [PX4-Autopilot repository](https://github.com/PX4/PX4-Autopilot).
+
+The definitions here are **synchronized automatically**: a [CI/CD pipeline](https://github.com/PX4/PX4-Autopilot/blob/main/.github/workflows/metadata.yml) in PX4-Autopilot pushes the updated ROS message definitions to this repository whenever the upstream definitions change, and a new versioned set is published when a PX4 release is created. As a result, the `main` branch here is kept in sync with the `main` branch of PX4-Autopilot.
+
+Any fix or improvement to a message or service definition must therefore be made on the uORB message files in PX4-Autopilot — follow the [PX4 contributing guide](https://github.com/PX4/PX4-Autopilot/blob/main/CONTRIBUTING.md).
+
+## Contributing to the repository infrastructure
+
+Changes to the packaging, build system, CI, or documentation **are** welcome here. To contribute:
+
+1. Fork the repository and create a topic branch off `main`.
+2. Make your changes and update the [`CHANGELOG.rst`](CHANGELOG.rst) when appropriate.
+3. Ensure the package still builds and tests pass:
+   ```sh
+   colcon build --packages-select px4_msgs
+   colcon test --packages-select px4_msgs
+   ```
+4. (Optional but recommended) install and run [`pre-commit`](https://pre-commit.com):
+   ```sh
+   pre-commit install
+   pre-commit run --all-files
+   ```
+5. Open a pull request, filling in the [pull request template](.github/PULL_REQUEST_TEMPLATE.md).
+
+### Commit conventions
+
+Please write [Conventional Commits](https://www.conventionalcommits.org/) and sign off your work under the [Developer Certificate of Origin](https://developercertificate.org/) using `git commit -s`.
+
+### Code of Conduct
+
+By participating, you are expected to uphold our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Release process
+
+Releases are automated end to end:
+
+1. The upstream PX4 message-sync bot updates `main`/`release/**` and bumps the package version. The [`Create GitHub release`](.github/workflows/create-release.yml) workflow detects a new `vX.Y.Z` and publishes a GitHub release, with notes auto-generated from the message/service diff against the previous release by [`scripts/generate_release_notes.sh`](scripts/generate_release_notes.sh).
+2. Publishing a release triggers the [`Package (.deb)`](.github/workflows/package.yml) workflow, which builds the Debian packages for every supported ROS 2 distribution and architecture and attaches them to the release.
+3. It also triggers the [`Release to rosdistro (bloom)`](.github/workflows/release.yml) workflow, which opens the release pull request against [`ros/rosdistro`](https://github.com/ros/rosdistro) so the package is built by the official ROS build farm.
+
+The in-repo [`CHANGELOG.rst`](CHANGELOG.rst) can be regenerated from the tag history at any time with [`scripts/generate_changelog.sh --in-place`](scripts/generate_changelog.sh).
+
+### One-time setup required
+
+These steps must be done once by a maintainer before the automation is fully operational:
+
+- Releases use a single release repository, [`PX4/px4_msgs-release`](https://github.com/PX4/px4_msgs-release). (The separate `PX4/px4_msgs2-release` was a ROS 2-only split; it has been archived in favour of the single `px4_msgs-release` and is not referenced by any current ROS distribution.) Seed a bloom track for each current distribution (`humble`, `jazzy`, `kilted`, `rolling`) once with an interactive `bloom-release` using `main` as the upstream devel branch, e.g.:
+  ```sh
+  bloom-release --rosdistro jazzy --new-track px4_msgs
+  ```
+- That first run also opens the pull request that adds the `release:` block for `px4_msgs` to [`ros/rosdistro`](https://github.com/ros/rosdistro) (today it has only `source:`/`doc:`, so the package is not yet built as binaries on the farm). After the tracks and the `release:` block exist, the [`Release to rosdistro (bloom)`](.github/workflows/release.yml) workflow automates subsequent releases.
+- Add a `BLOOM_GITHUB_TOKEN` repository secret: a token that can push to `PX4/px4_msgs-release` and open a pull request on `ros/rosdistro`.
+- Add a `RELEASE_TOKEN` repository secret (a PAT) so that releases created by the automation cascade into the packaging and bloom workflows. Releases created with the default `GITHUB_TOKEN` do not trigger downstream workflows.

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -1,0 +1,104 @@
+This document is a declaration of software quality for the `px4_msgs` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `px4_msgs` Quality Declaration
+
+The package `px4_msgs` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`px4_msgs` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://docs.ros.org/en/rolling/Contributing/Developer-Guide.html#versioning).
+
+### Version Stability [1.ii]
+
+`px4_msgs` is at a stable version, i.e. `>= 1.0.0`. The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All message and service definitions found in the `msg/` and `srv/` directories make up the public API of the package. These definitions are generated from, and kept in sync with, the [uORB message definitions](https://github.com/PX4/PX4-Autopilot/tree/main/msg) in the PX4-Autopilot repository.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`px4_msgs` will not break public API within a released ROS 2 distribution, i.e. no major releases once the ROS distribution is released. Each PX4 release line is tracked on a dedicated `release/*` branch, as documented in the [README](README.md).
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`px4_msgs` contains generated C/C++ code and therefore is subject to ABI breaks. ABI stability is maintained within a released ROS 2 distribution by only making message changes on the development (`main`) and unreleased branches.
+
+## Change Control Process [2]
+
+`px4_msgs` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://docs.ros.org/en/rolling/Contributing/Developer-Guide.html#change-control-process).
+
+### Change Requests [2.i]
+
+All changes will occur through a pull request, following the [contributing guidelines](CONTRIBUTING.md). Message and service definitions are not edited directly here; they are synchronized from PX4-Autopilot.
+
+### Contributor Origin [2.ii]
+
+This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](CONTRIBUTING.md).
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers). The CI is configured in [`.github/workflows/build.yml`](.github/workflows/build.yml) and builds the package against the ROS 2 distributions currently on the build farm.
+
+### Documentation Policy [2.v]
+
+All pull requests that change the public API must update documentation accordingly. As the public API is generated from upstream uORB definitions, documentation for the messages is maintained alongside those definitions in PX4-Autopilot.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`px4_msgs` provides ROS 2 message and service definitions. Usage is documented in the [README](README.md) and in the [PX4 ROS 2 User Guide](https://docs.px4.io/main/en/ros/ros2_comm.html).
+
+### Public API Documentation [3.ii]
+
+The public API consists of the message and service definitions, which are self-documenting and carry inline comments inherited from the upstream uORB definitions.
+
+### License [3.iii]
+
+The license for `px4_msgs` is BSD-3-Clause, and a summary can be found in the [package.xml](package.xml). The full license text is in [LICENSE](LICENSE). There is an automated test (`ament_copyright`) that runs to confirm the license headers, configured via the `BUILD_TESTING` block of [CMakeLists.txt](CMakeLists.txt).
+
+### Copyright Statement [3.iv]
+
+The copyright holders are listed in [LICENSE](LICENSE).
+
+## Testing [4]
+
+As `px4_msgs` is an interface-only package, it does not contain feature or unit tests beyond linting and the verification that all interfaces build and generate type support successfully across all target platforms via CI.
+
+### Feature Testing [4.i] / Public API Testing [4.ii]
+
+Not applicable. Successful generation of the interfaces in CI exercises the public API.
+
+### Coverage [4.iii] / Performance [4.iv]
+
+Not applicable for an interface-only package.
+
+### Linters and Static Analysis [4.v]
+
+`px4_msgs` uses and passes all the standard linters and static analysis tools for an interface package as described in the [ROS 2 Developer Guide](https://docs.ros.org/en/rolling/Contributing/Developer-Guide.html#linters-and-static-analysis). The linters are enabled through `ament_lint_auto` / `ament_lint_common` in the `BUILD_TESTING` block of [CMakeLists.txt](CMakeLists.txt) and additionally via [`pre-commit`](.pre-commit-config.yaml).
+
+## Dependencies [5]
+
+`px4_msgs` has the following runtime ROS dependencies, which are at or above Quality Level 3:
+
+* `builtin_interfaces`
+* `rosidl_default_runtime`
+
+It has several "buildtool" dependencies, which do not affect the resulting quality, and "test" dependencies that are only used to test the package itself.
+
+## Platform Support [6]
+
+`px4_msgs` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against them via CI.
+
+## Security [7]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html). See [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -1,57 +1,158 @@
 # px4_msgs
 
-[![GitHub license](https://img.shields.io/github/license/PX4/px4_msgs.svg)](https://github.com/PX4/px4_msg/blob/master/LICENSE) [![Build package](https://github.com/PX4/px4_msgs/workflows/Build%20package/badge.svg)](https://github.com/PX4/px4_msgs/actions)
+<!-- status -->
+[![Build package](https://github.com/PX4/px4_msgs/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/PX4/px4_msgs/actions/workflows/build.yml)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/PX4/px4_msgs/blob/main/.pre-commit-config.yaml)
+[![Latest release](https://img.shields.io/github/v/release/PX4/px4_msgs?logo=github&label=release&color=blue)](https://github.com/PX4/px4_msgs/releases/latest)
+[![Last commit](https://img.shields.io/github/last-commit/PX4/px4_msgs/main?logo=git&logoColor=white)](https://github.com/PX4/px4_msgs/commits/main)
+<!-- ecosystem -->
+[![ROS 2](https://img.shields.io/badge/ROS%202-Humble%20%7C%20Jazzy%20%7C%20Kilted%20%7C%20Rolling%20%7C%20Lyrical-22314E?logo=ros&logoColor=white)](https://index.ros.org/p/px4_msgs/)
+[![REP-2004 Quality Level 3](https://img.shields.io/badge/Quality%20Level-3-yellowgreen)](QUALITY_DECLARATION.md)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-FE5196?logo=conventionalcommits&logoColor=white)](https://www.conventionalcommits.org)
+[![License: BSD-3-Clause](https://img.shields.io/github/license/PX4/px4_msgs?color=brightgreen)](https://github.com/PX4/px4_msgs/blob/main/LICENSE)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/PX4/px4_msgs/blob/main/CONTRIBUTING.md)
+[![Dronecode Discord](https://img.shields.io/discord/1022170275984457759?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/dronecode)
 
-[![Discord Shield](https://discordapp.com/api/guilds/1022170275984457759/widget.png?style=shield)](https://discord.gg/dronecode)
+ROS 2 message and service definitions for the [PX4 Autopilot](https://px4.io/).
 
-ROS 2 message definitions for the [PX4 Autopilot](https://px4.io/) project.
+## Overview
 
-Building this package generates all the required interfaces to interface ROS 2 nodes with the PX4 internals.
+`px4_msgs` is a ROS 2 **interface package**: it contains only `.msg` and `.srv` definitions and the build rules that turn them into the C++/Python interfaces used by ROS 2 applications. The definitions mirror PX4's internal [uORB](https://docs.px4.io/main/en/middleware/uorb.html) topics, so that a ROS 2 node can exchange them with the autopilot over the [uXRCE-DDS bridge](https://docs.px4.io/main/en/middleware/uxrce_dds.html) (the `uxrce_dds_client` running on PX4 talks to the `MicroXRCEAgent` running on the companion side, which publishes/subscribes these topics on the ROS 2 graph).
+
+Because the definitions come straight from PX4, this package is the single source of truth that keeps a ROS 2 workspace ABI-compatible with a given PX4 firmware version.
+
+## Installation
+
+### From source (recommended today)
+
+Clone the branch that matches your PX4 version (see [Supported versions](#supported-versions-and-compatibility)) into a colcon workspace and build:
+
+```sh
+mkdir -p ~/ros2_ws/src && cd ~/ros2_ws/src
+git clone https://github.com/PX4/px4_msgs.git
+cd ~/ros2_ws
+source /opt/ros/jazzy/setup.bash      # or humble / kilted / rolling
+colcon build --packages-select px4_msgs
+```
+
+See [Using colcon to build packages](https://docs.ros.org/en/rolling/Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package.html#build-a-package) and the [PX4 ROS 2 User Guide](https://docs.px4.io/main/en/ros/ros2_comm.html) for the full workflow.
+
+### From a binary (apt)
+
+Once the package has completed its [build-farm release](#releasing) it is installable as a Debian package:
+
+```sh
+sudo apt install ros-${ROS_DISTRO}-px4-msgs
+```
+
+You can also build a `.deb` locally — see [Building Debian packages](#building-debian-packages).
+
+## Usage
+
+After sourcing the workspace, the generated interfaces are available like any other ROS 2 message package:
+
+```cpp
+#include <px4_msgs/msg/vehicle_status.hpp>
+// ...
+sub_ = create_subscription<px4_msgs::msg::VehicleStatus>(
+  "/fmu/out/vehicle_status", rclcpp::QoS(10).best_effort(),
+  [](px4_msgs::msg::VehicleStatus::SharedPtr msg) { /* ... */ });
+```
+
+```python
+from px4_msgs.msg import VehicleStatus
+```
+
+> **Note:** PX4 publishes with *best-effort* QoS; subscribers must use a compatible QoS profile (as above) or they will not receive any data. Topic names and directions (`/fmu/out/...`, `/fmu/in/...`) are documented in the [PX4 uXRCE-DDS topic list](https://docs.px4.io/main/en/middleware/dds_topics.html).
+
+## Package layout
+
+```text
+px4_msgs/
+├── msg/            # message definitions (*.msg), generated from PX4 uORB
+├── srv/            # service definitions (*.srv)
+├── CMakeLists.txt  # globs msg/ and srv/ and calls rosidl_generate_interfaces
+└── package.xml     # ament_cmake, format 3, member of rosidl_interface_packages
+```
 
 ## Supported versions and compatibility
 
-Depending on the PX4 and ROS versions you want to use, you need to checkout the appropriate branch of this package:
+`px4_msgs` is a pure interface package, so the definitions build on **any maintained ROS 2 distribution**. What ties a checkout to a firmware is the **PX4 release line**, not the ROS 2 distribution: each PX4 release has its own branch and `main` tracks PX4 `main`. Pick the branch that matches the PX4 version you fly, then build it on whichever ROS 2 distribution you run.
 
-| PX4            | ROS 2   | Ubuntu       | branch                                                            |
-|----------------|---------|--------------|-------------------------------------------------------------------|
-| [v1.13](https://github.com/PX4/px4_msgs/tree/release/1.13)           | Foxy    | Ubuntu 20.04 | [release/1.13](https://github.com/PX4/px4_msgs/tree/release/1.13) |
-| [v1.14](https://github.com/PX4/px4_msgs/tree/release/1.14)           | Foxy    | Ubuntu 20.04 | [release/1.14](https://github.com/PX4/px4_msgs/tree/release/1.14) |
-| [v1.14](https://github.com/PX4/px4_msgs/tree/release/1.14)           | Humble  | Ubuntu 22.04 | [release/1.14](https://github.com/PX4/px4_msgs/tree/release/1.14) |
-| [v1.14](https://github.com/PX4/px4_msgs/tree/release/1.14)           | Rolling | Ubuntu 22.04 | [release/1.14](https://github.com/PX4/px4_msgs/tree/release/1.14) |
-| [v1.15](https://github.com/PX4/px4_msgs/tree/release/1.15)           | Foxy    | Ubuntu 20.04 | [release/1.15](https://github.com/PX4/px4_msgs/tree/release/1.15) |
-| [v1.15](https://github.com/PX4/px4_msgs/tree/release/1.15)           | Humble  | Ubuntu 22.04 | [release/1.15](https://github.com/PX4/px4_msgs/tree/release/1.15) |
-| [v1.15](https://github.com/PX4/px4_msgs/tree/release/1.15)           | Rolling | Ubuntu 22.04 | [release/1.15](https://github.com/PX4/px4_msgs/tree/release/1.15) |
-| [main](https://github.com/PX4/px4_msgs/tree/main)                    | Foxy    | Ubuntu 22.04 | [main](https://github.com/PX4/px4_msgs)                           |
-| [main](https://github.com/PX4/px4_msgs/tree/main)                    | Humble  | Ubuntu 22.04 | [main](https://github.com/PX4/px4_msgs)                           |
-| [main](https://github.com/PX4/px4_msgs/tree/main)                    | Rolling | Ubuntu 22.04 | [main](https://github.com/PX4/px4_msgs)                           |
+### PX4 release → px4_msgs branch
 
-### Messages Sync from PX4
+| PX4 release             | px4_msgs branch                                                     |
+|-------------------------|--------------------------------------------------------------------|
+| `main` (in development) | [`main`](https://github.com/PX4/px4_msgs)                          |
+| v1.17                   | [`release/1.17`](https://github.com/PX4/px4_msgs/tree/release/1.17) |
+| v1.16                   | [`release/1.16`](https://github.com/PX4/px4_msgs/tree/release/1.16) |
+| v1.15                   | [`release/1.15`](https://github.com/PX4/px4_msgs/tree/release/1.15) |
+| v1.14                   | [`release/1.14`](https://github.com/PX4/px4_msgs/tree/release/1.14) |
+| v1.13                   | [`release/1.13`](https://github.com/PX4/px4_msgs/tree/release/1.13) |
 
-When PX4 message definitions in the `main` branch of [PX4 Autopilot](https://github.com/PX4/PX4-Autopilot) change, a [CI/CD pipeline](https://github.com/PX4/PX4-Autopilot/blob/main/.github/workflows/metadata.yml#L119) automatically copies and pushes updated ROS message definitions to this repository. This ensures that this repository `main` branch and the PX4-Autopilot `main` branch are always up to date.
-However, if you are using a custom PX4 version and you modified existing messages or created new one, then you have to manually synchronize them in this repository:
-### Manual Message Sync
+### ROS 2 distribution → Ubuntu
 
-- Checkout the correct branch associated to the PX4 version from which you detached you custom version.
-- Delete all `*.msg` and `*.srv` files in `msg/` and  `srv/`.
-- Copy all `*.msg` and  `*.srv` files from `PX4-Autopilot/msg/` and `PX4-Autopilot/srv/` in  `msg/` and  `srv/`, respectively. Assuming that this repository and the PX4-Autopilot repository are placed in your home folder, you can run:
+The ROS 2 distribution fixes the Ubuntu version ([REP 2000](https://www.ros.org/reps/rep-2000.html)). CI builds `main` against every maintained distribution:
+
+| ROS 2 distribution | Ubuntu             | Type                | Built in CI                                                  |
+|--------------------|--------------------|---------------------|-------------------------------------------------------------|
+| Humble             | 22.04 (Jammy)      | LTS, until 2027     | yes, native runner                                          |
+| Jazzy              | 24.04 (Noble)      | LTS, until 2029     | yes, native runner                                          |
+| Kilted             | 24.04 (Noble)      | non-LTS, until 2026 | yes, native runner                                          |
+| Rolling            | 24.04 (Noble)      | development         | yes, native runner                                          |
+| Lyrical            | 26.04 (Resolute)   | LTS                 | yes, in the `ros:lyrical` container (no 26.04 runner yet)   |
+| Foxy               | 20.04 (Focal)      | EOL since 2023      | no                                                          |
+
+The definitions use only basic message features (built in types, fixed size arrays, nested messages), so any branch also builds on the older distributions if you still need them; the `release/*` branches were originally tested on Foxy, Humble and Rolling. Windows (Jazzy) and macOS (Jazzy, via [RoboStack](https://robostack.github.io/)) are covered by CI as well.
+
+## How the definitions are kept in sync (px4_msgs quirks)
+
+This package is **generated, not hand-written** — keep these PX4-specific points in mind:
+
+- **Do not edit `msg/` or `srv/` here.** The definitions are copied from the [uORB definitions](https://github.com/PX4/PX4-Autopilot/tree/main/msg) in PX4-Autopilot. Fix a message at the source (PX4-Autopilot) instead. See [CONTRIBUTING.md](CONTRIBUTING.md).
+- **Automatic sync.** When the uORB definitions change on PX4-Autopilot `main`, a [CI pipeline](https://github.com/PX4/PX4-Autopilot/blob/main/.github/workflows/metadata.yml) pushes the updated definitions here, so `main` stays in lock-step with PX4-Autopilot `main`.
+- **Flat layout requirement.** The ROS 2 generation pipeline requires every definition to live **directly** under `msg/` (no sub-directories) — PX4's `msg/versioned/` files are flattened into `msg/` during the sync.
+- **Manual sync** (only needed for a custom/detached PX4 version): check out the branch for the PX4 version you forked from, then refresh the definitions:
   ```sh
-  rm -f ~/px4_msgs/msg/*.msg
-  rm -f ~/px4_msgs/srv/*.srv
-  cp ~/PX4-Autopilot/msg/*.msg ~/px4_msgs/msg/
-  cp ~/PX4-Autopilot/msg/versioned/*.msg ~/px4_msgs/msg/
-  cp ~/PX4-Autopilot/srv/*.srv ~/px4_msgs/srv/
+  rm -f msg/*.msg srv/*.srv
+  cp ~/PX4-Autopilot/msg/*.msg msg/
+  cp ~/PX4-Autopilot/msg/versioned/*.msg msg/
+  cp ~/PX4-Autopilot/srv/*.srv srv/
   ```
-**Note:** The ROS 2 message generation pipeline requires all messages to be directly under `msg/` and doesn't support sub-directories.
 
-## Install, build and usage
+## Building Debian packages
 
-Check [Using colcon to build packages](https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Creating-Your-First-ROS2-Package.html#build-a-package) to understand how this can be built inside a workspace. Check the [PX4 ROS 2 User Guide](https://docs.px4.io/main/en/ros/ros2_comm.html) section on the PX4 documentation for further details on how this integrates PX4 and how to exchange messages with the autopilot.
+Official binaries are produced by the [ROS build farm](https://build.ros.org/) via [`bloom`](https://wiki.ros.org/bloom). To build a `.deb` locally (e.g. to self-host or test packaging), use the bundled builder container, which wraps `bloom-generate rosdebian` and writes the result to `./out`:
 
-## Bug tracking and feature requests
+```sh
+./scripts/build_deb_host.sh                 # default: humble
+ROS_DISTRO=jazzy ./scripts/build_deb_host.sh
+```
 
-Use the [Issues](https://github.com/PX4/px4_msgs/issues) section to create a new issue. Report your issue or feature request [here](https://github.com/PX4/px4_msgs/issues/new).
+The same packaging runs in CI for every supported distribution on `amd64` and `arm64` ([`Package (.deb)`](.github/workflows/package.yml)). `.deb` packages are Debian/Ubuntu-specific; there is no equivalent on Windows or macOS.
 
-## Questions and troubleshooting
+## Releasing
 
-Reach the PX4 development team on the [PX4 Discord Server](https://discord.gg/dronecode).
+Releases are automated: a GitHub release (created from an upstream PX4 version bump) triggers the `.deb` packaging and a `bloom` pull request to [`ros/rosdistro`](https://github.com/ros/rosdistro), using the [`PX4/px4_msgs-release`](https://github.com/PX4/px4_msgs-release) release repository. See the [release process](CONTRIBUTING.md#release-process) in CONTRIBUTING for the one-time setup.
 
+Each ROS 2 distribution is released from the matching PX4 release line (see the table above), and `bloom` only accepts increasing versions per distribution. So a later patch on an older line (e.g. `1.16.3` after `1.17.0`) is released to the distributions that track `1.16`, and never overrides a newer release already published for another distribution.
+
+## Contributing
+
+Contributions to the packaging, build, CI, and docs are welcome — read the [contributing guide](CONTRIBUTING.md) and use the [pull request template](.github/PULL_REQUEST_TEMPLATE.md). Remember that message/service definitions are changed in [PX4-Autopilot](https://github.com/PX4/PX4-Autopilot), not here. All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Quality declaration
+
+`px4_msgs` claims Quality Level 3 — see the [Quality Declaration](QUALITY_DECLARATION.md) ([REP-2004](https://www.ros.org/reps/rep-2004.html)).
+
+## Support
+
+- **Bugs / features (this package):** [GitHub Issues](https://github.com/PX4/px4_msgs/issues)
+- **Message/field changes:** [PX4-Autopilot issues](https://github.com/PX4/PX4-Autopilot/issues)
+- **Questions / troubleshooting:** [PX4 Discord](https://discord.gg/dronecode)
+- **Security:** see the [security policy](SECURITY.md)
+- **Release history:** [CHANGELOG.rst](CHANGELOG.rst)
+
+## License
+
+Released under the [BSD 3-Clause License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+This package follows the ROS 2 vulnerability disclosure guidance in [REP-2006](https://www.ros.org/reps/rep-2006.html).
+
+## Scope
+
+`px4_msgs` contains only ROS 2 message and service definitions, which are generated and synchronized automatically from [PX4-Autopilot](https://github.com/PX4/PX4-Autopilot). Vulnerabilities in the *content* of the definitions or in PX4 itself should be reported to the PX4 project. This policy covers the packaging, build, and CI tooling maintained in this repository.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security-sensitive reports.
+
+Instead, use one of the following private channels:
+
+- Open a [private security advisory][advisory] on this repository (**Security → Report a vulnerability**), or
+- Contact the maintainers listed in [`package.xml`](package.xml).
+
+For vulnerabilities affecting PX4 more broadly, follow the [PX4 security policy](https://github.com/PX4/PX4-Autopilot/security/policy).
+
+When reporting, please include:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce or a proof of concept.
+- The affected branch / version (e.g. `main`, `release/1.17`).
+
+We will acknowledge your report as soon as possible and keep you informed of the progress towards a fix.
+
+[advisory]: https://github.com/PX4/px4_msgs/security/advisories/new

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,29 @@
+# Builder image for generating px4_msgs Debian packages with bloom.
+# The ROS 2 distribution is selectable so packages can be produced for every
+# distribution on the build farm (humble, jazzy, kilted, rolling, ...).
+ARG ROS_DISTRO=humble
+FROM ros:${ROS_DISTRO}-ros-core
+
+# Redeclare after FROM so it is available in the build stage.
+ARG ROS_DISTRO
+ENV ROS_DISTRO=${ROS_DISTRO}
+
+# The tooling required to resolve dependencies and generate/build the Debian
+# package. build-essential provides the C/C++ compiler the message typesupport
+# build needs; no runtime middleware is needed for an interface package.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  python3-bloom \
+  python3-rosdep \
+  build-essential \
+  cmake \
+  fakeroot \
+  debhelper \
+  dh-python \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN rosdep init && rosdep update
+
+WORKDIR /work
+
+COPY container/build_deb_container.sh /usr/local/bin/build.sh
+RUN chmod +x /usr/local/bin/build.sh

--- a/container/build_deb_container.sh
+++ b/container/build_deb_container.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script runs INSIDE the px4_msgs-builder container.
+# Assumptions:
+#   /src        -> px4_msgs source tree (mounted from host)
+#   /artifacts  -> output dir (mounted from host, write .deb here)
+#   ROS_DISTRO  -> ROS 2 distribution to target (provided by the image)
+
+: "${ROS_DISTRO:?ROS_DISTRO must be set (provided by the builder image)}"
+
+# Debian packaging is Debian/Ubuntu specific. The OS name defaults to ubuntu
+# and the OS version is auto-detected by bloom from the base image, so each
+# ROS 2 distribution is packaged for its matching Ubuntu release (jammy for
+# humble, noble for jazzy/kilted/rolling, ...).
+OS_NAME="${OS_NAME:-ubuntu}"
+
+echo "[*] Building px4_msgs Debian package for ROS 2 ${ROS_DISTRO} (${OS_NAME})"
+
+echo "[*] Cleaning previous build artifacts"
+cd /src
+rm -rf debian obj-* .obj-* CMakeCache.txt CMakeFiles build install log || true
+
+echo "[*] Resolving build dependencies with rosdep"
+rosdep install --from-paths . --ignore-src -y --rosdistro "${ROS_DISTRO}"
+
+echo "[*] Generating Debian packaging with bloom"
+bloom-generate rosdebian --os-name "${OS_NAME}" --ros-distro "${ROS_DISTRO}"
+
+echo "[*] Building Debian package with fakeroot"
+# Skip the test suite while packaging; the linters/tests run in the build CI.
+DEB_BUILD_OPTIONS=nocheck fakeroot debian/rules binary
+
+echo "[*] Copying artifacts to /artifacts"
+cp /*.deb /artifacts/ 2>/dev/null || true
+cp /*.ddeb /artifacts/ 2>/dev/null || true
+
+echo "[*] Done. Artifacts in /artifacts"

--- a/package.xml
+++ b/package.xml
@@ -2,20 +2,27 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>px4_msgs</name>
-  <version>2.0.1</version>
+  <version>1.17.0</version>
   <description>Package with the ROS-equivalent of PX4 uORB msgs</description>
   <maintainer email="nuno.marques@dronesolutions.io">Nuno Marques</maintainer>
+  <maintainer email="beniamino.pozzan@gmail.com">Beniamino Pozzan</maintainer>
+  <maintainer email="mrpollo@gmail.com">Ramon Roche</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <url type="website">https://github.com/PX4/px4_msgs</url>
+  <url type="repository">https://github.com/PX4/px4_msgs</url>
+  <url type="bugtracker">https://github.com/PX4/px4_msgs/issues</url>
+
   <author email="nuno.marques@dronesolutions.io">Nuno Marques</author>
-  <license>BSD 3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
-  <depend>ros_environment</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/scripts/build_deb_host.sh
+++ b/scripts/build_deb_host.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build px4_msgs Debian packages locally using the bundled builder container.
+#
+# Usage:
+#   ./scripts/build_deb_host.sh            # builds for humble (default)
+#   ROS_DISTRO=jazzy ./scripts/build_deb_host.sh
+#
+# The resulting *.deb files are written to ./out
+
+# Location of this script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( realpath "${SCRIPT_DIR}/.." )"
+
+# Source dir is the repo root (px4_msgs checkout)
+SRC_DIR="${REPO_ROOT}"
+
+# Output dir for built .deb files
+OUT_DIR="${REPO_ROOT}/out"
+
+# ROS 2 distribution to build for (default: humble)
+ROS_DISTRO="${ROS_DISTRO:-humble}"
+IMAGE="px4io/px4_msgs-builder:${ROS_DISTRO}"
+
+mkdir -p "${OUT_DIR}"
+
+echo "[*] Building px4_msgs .deb packages"
+echo "[*] ROS distro: ${ROS_DISTRO}"
+echo "[*] Source:     ${SRC_DIR}"
+echo "[*] Artifacts:  ${OUT_DIR}"
+
+echo "[*] Building builder image ${IMAGE}"
+docker build \
+    --build-arg "ROS_DISTRO=${ROS_DISTRO}" \
+    -t "${IMAGE}" \
+    -f "${REPO_ROOT}/container/Dockerfile" \
+    "${REPO_ROOT}"
+
+echo "[*] Running the build in a container"
+docker run --rm \
+    -v "${SRC_DIR}":/src \
+    -v "${OUT_DIR}":/artifacts \
+    "${IMAGE}" \
+    /usr/local/bin/build.sh
+
+echo "[*] Done. Check ${OUT_DIR} for .deb files"

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+set -euo pipefail
+
+# Regenerate CHANGELOG.rst from the git tag history in the catkin_pkg / bloom
+# RST format. Each released version entry is derived mechanically:
+#   * the date comes from the version tag,
+#   * the contributors come from the git authors in that tag's range,
+#   * the summary comes from the msg/srv diff against the previous tag.
+#
+# The hand-curated "Forthcoming" section (unreleased changes) at the top of the
+# existing CHANGELOG.rst is preserved verbatim.
+#
+# Usage:
+#   scripts/generate_changelog.sh            # write the changelog to stdout
+#   scripts/generate_changelog.sh --in-place # overwrite CHANGELOG.rst
+#   scripts/generate_changelog.sh --check    # exit 1 if CHANGELOG.rst is stale
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( realpath "${SCRIPT_DIR}/.." )"
+cd "${REPO_ROOT}"
+
+CHANGELOG="CHANGELOG.rst"
+mode="stdout"
+case "${1:-}" in
+  --in-place) mode="in-place" ;;
+  --check)    mode="check" ;;
+  "")         mode="stdout" ;;
+  *) echo "Unknown option: $1" >&2; exit 2 ;;
+esac
+
+underline() { # text char
+  printf '%s\n' "$1"
+  printf '%*s\n' "${#1}" '' | tr ' ' "$2"
+}
+
+join_csv() { paste -sd ',' - | sed 's/,/, /g'; }
+
+names() { # base tag filter
+  git diff --diff-filter="$3" --name-only "$1" "$2" -- msg srv \
+    | sed 's#.*/##; s/\.\(msg\|srv\)$//' | sort | join_csv
+}
+
+contributors() { # range_or_empty
+  local range="$1" out
+  if [ -n "${range}" ]; then
+    out="$(git log "${range}" --format='%an' 2>/dev/null \
+      | sed -E 's/.*[Bb]uild ?[Bb]ot.*/PX4 BuildBot/' \
+      | sort -u | grep -v '^$' | join_csv)"
+  fi
+  [ -n "${out:-}" ] && echo "${out}" || echo "PX4 BuildBot"
+}
+
+# Preserve an existing "Forthcoming" block (from its heading up to the first
+# released "X.Y.Z (" heading), if present.
+forthcoming_block() {
+  if [ -f "${CHANGELOG}" ]; then
+    awk '
+      /^Forthcoming$/ {grab=1}
+      grab && /^[0-9]+\.[0-9]+\.[0-9]+ \(/ {exit}
+      grab {print}
+    ' "${CHANGELOG}"
+  fi
+}
+
+generate() {
+  underline "Changelog for package px4_msgs" "^"
+  echo
+  cat <<'EOF'
+The version numbers of this package track the corresponding `PX4 Autopilot
+<https://github.com/PX4/PX4-Autopilot>`_ release line. The message and service
+definitions are generated and synchronized automatically from the uORB
+definitions in PX4-Autopilot, so the entries below are produced from the tagged
+release history rather than by manual edits (see
+``scripts/generate_changelog.sh``).
+EOF
+  echo
+
+  # The "Forthcoming" section is the standard catkin/bloom staging area for
+  # unreleased changes. It is optional here: it is kept only when it has been
+  # curated with real content, otherwise it is omitted.
+  local fc
+  fc="$(forthcoming_block | sed -E '/^Forthcoming$/d; /^-+$/d; /^[[:space:]]*$/d; /^\*[[:space:]]*\(none\)[[:space:]]*$/d')"
+  if [ -n "${fc}" ]; then
+    printf '%s\n\n' "$(forthcoming_block)" | sed -E '/^[[:space:]]*$/{ N; /^[[:space:]]*\n[[:space:]]*$/D }'
+  fi
+
+  # Iterate tags newest -> oldest.
+  local tags
+  tags="$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)"
+  while read -r tag; do
+    [ -z "${tag}" ] && continue
+    local version date prev_tag range
+    version="${tag#v}"
+    date="$(git log -1 --format=%ad --date=short "${tag}")"
+    prev_tag="$(git tag --sort=v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+      | awk -v t="${tag}" '$0==t{print p; exit} {p=$0}')"
+
+    underline "${version} (${date})" "-"
+
+    if [ -z "${prev_tag}" ]; then
+      echo "* Initial tracked release, synchronized with PX4 Autopilot ${version}."
+      range=""
+    elif [ "$(git rev-parse "${prev_tag}^{tree}")" = "$(git rev-parse "${tag}^{tree}")" ]; then
+      echo "* PX4 point release; message and service definitions identical to ${prev_tag#v}."
+      range=""
+    else
+      echo "* Synchronized with PX4 Autopilot ${version}."
+      local added removed changed
+      added="$(names "${prev_tag}" "${tag}" A)"
+      removed="$(names "${prev_tag}" "${tag}" D)"
+      changed="$(git diff --diff-filter=M --name-only "${prev_tag}" "${tag}" -- msg srv | wc -l | tr -d ' ')"
+      [ -n "${added}" ]   && echo "* Added: ${added}."
+      [ -n "${removed}" ] && echo "* Removed: ${removed}."
+      [ "${changed}" != "0" ] && echo "* Changed ${changed} message/service definition(s)."
+      range="${prev_tag}..${tag}"
+    fi
+    echo "* Contributors: $(contributors "${range}")"
+    echo
+  done <<< "${tags}"
+}
+
+# Emit the changelog with exactly one trailing newline (no trailing blank line).
+emit() { local c; c="$(generate)"; printf '%s\n' "${c}"; }
+
+case "${mode}" in
+  stdout)   emit ;;
+  in-place) emit > "${CHANGELOG}"; echo "Wrote ${CHANGELOG}" >&2 ;;
+  check)
+    tmp="$(mktemp)"
+    emit > "${tmp}"
+    if ! diff -q "${tmp}" "${CHANGELOG}" >/dev/null 2>&1; then
+      echo "CHANGELOG.rst is out of date. Run: scripts/generate_changelog.sh --in-place" >&2
+      diff -u "${CHANGELOG}" "${tmp}" || true
+      rm -f "${tmp}"; exit 1
+    fi
+    rm -f "${tmp}"; echo "CHANGELOG.rst is up to date." >&2 ;;
+esac

--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+set -euo pipefail
+
+# Generate Markdown release notes for a px4_msgs version by diffing the message
+# and service definitions against the previous release. The notes mirror the
+# upstream PX4 uORB changes: which interfaces were added, removed, or changed
+# (with field/constant level detail).
+#
+# Usage:
+#   scripts/generate_release_notes.sh [<tag>] [<base-ref>]
+#
+#   <tag>       Release tag to describe (default: the version from package.xml,
+#               prefixed with "v").
+#   <base-ref>  Ref to diff against (default: the previous version tag).
+#
+# The output is written to stdout.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( realpath "${SCRIPT_DIR}/.." )"
+cd "${REPO_ROOT}"
+
+# Resolve the tag to describe.
+tag="${1:-}"
+if [ -z "${tag}" ]; then
+  version="$(sed -n 's:.*<version>\(.*\)</version>.*:\1:p' package.xml | head -n1)"
+  tag="v${version}"
+fi
+
+# Resolve the base ref (previous version tag) unless given explicitly.
+base="${2:-}"
+if [ -z "${base}" ]; then
+  base="$(git tag --sort=v:refname | awk -v t="${tag}" '$0==t{print p; exit} {p=$0}')"
+fi
+
+pxver="${tag#v}"
+
+header() {
+  echo "Message and service definitions synchronized with **PX4 Autopilot ${pxver}**."
+  echo
+  echo "Changes are mirrored from the upstream uORB definitions in [PX4-Autopilot](https://github.com/PX4/PX4-Autopilot)."
+}
+
+# No previous release to diff against: describe the baseline.
+if [ -z "${base}" ]; then
+  header
+  echo
+  count="$(git ls-tree -r --name-only "${tag}" -- msg srv | grep -cE '\.(msg|srv)$' || true)"
+  echo "Initial release of this line, providing ${count} message and service definitions."
+  exit 0
+fi
+
+# Re-tag of the same commit: no interface changes.
+if [ "$(git rev-parse "${base}^{tree}")" = "$(git rev-parse "${tag}^{tree}")" ]; then
+  header
+  echo
+  echo "This PX4 point release does not change any of the tracked message or service definitions — the interfaces are **identical to [${base}](https://github.com/PX4/px4_msgs/releases/tag/${base})**."
+  exit 0
+fi
+
+# Extract the set of declarations (fields/constants) of a file at a ref, with
+# comments and whitespace normalized away so comment-only churn is ignored.
+decls() { # ref path
+  git show "$1:$2" 2>/dev/null \
+    | sed -E 's/#.*$//' \
+    | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' \
+    | grep -vE '^$' \
+    | sort -u
+}
+
+namelist() { # filter
+  git diff --diff-filter="$1" --name-only "${base}" "${tag}" -- msg srv \
+    | sed 's#^msg/##; s#^srv/##' | sort
+}
+
+header
+echo
+echo "Summary of interface changes since [${base}](https://github.com/PX4/px4_msgs/releases/tag/${base}):"
+echo
+
+added="$(namelist A)"
+removed="$(namelist D)"
+modified="$(git diff --diff-filter=M --name-only "${base}" "${tag}" -- msg srv | sort)"
+
+if [ -n "${added}" ]; then
+  echo "### Added"
+  echo
+  while read -r f; do [ -n "$f" ] && echo "- \`$f\`"; done <<< "${added}"
+  echo
+fi
+
+if [ -n "${removed}" ]; then
+  echo "### Removed"
+  echo
+  while read -r f; do [ -n "$f" ] && echo "- \`$f\`"; done <<< "${removed}"
+  echo
+fi
+
+if [ -n "${modified}" ]; then
+  echo "### Changed"
+  echo
+  while read -r f; do
+    [ -z "$f" ] && continue
+    tmpb="$(mktemp)"; tmpt="$(mktemp)"
+    decls "${base}" "$f" > "${tmpb}"
+    decls "${tag}" "$f" > "${tmpt}"
+    add_d="$(comm -13 "${tmpb}" "${tmpt}")"
+    rem_d="$(comm -23 "${tmpb}" "${tmpt}")"
+    rm -f "${tmpb}" "${tmpt}"
+    if [ -z "${add_d}" ] && [ -z "${rem_d}" ]; then
+      echo "- **\`$(basename "$f")\`** — documentation/comment updates only"
+      continue
+    fi
+    echo "- **\`$(basename "$f")\`**"
+    while read -r l; do [ -n "$l" ] && echo "  - added \`$l\`"; done <<< "${add_d}"
+    while read -r l; do [ -n "$l" ] && echo "  - removed \`$l\`"; done <<< "${rem_d}"
+  done <<< "${modified}"
+  echo
+fi


### PR DESCRIPTION
## Description

Brings `px4_msgs` up to the standard practices expected of ROS 2 packages on the build farm, **and continues the Debian packaging work from #65** (cherry-picked, with @mrpollo's authorship preserved). No auto-generated `*.msg` / `*.srv` files are touched. History is kept to a small set of logical commits.

## Packaging & build
- `package.xml`: version `1.17.0` (matches the PX4 release line / `v1.17.0` tag, was a stale `2.0.1`), `url` tags, SPDX `BSD-3-Clause`, `ament_lint_auto` test dep, element order fixed to the package-format-3 schema, active maintainers listed, and the unused `ros_environment` dependency dropped (it doesn't resolve on newer distros).
- `CMakeLists.txt`: CMake 3.8, C++17, `rosidl_default_generators` found before the interface deps (required by newer rosidl on Rolling/Kilted), and `ament_lint_auto` enabled under `BUILD_TESTING` (copyright linter skipped — generated definitions carry no headers).

## Build-farm requirements
- `CHANGELOG.rst` in the catkin_pkg/bloom RST format, tracking the PX4 release line.
- `scripts/generate_changelog.sh` — regenerates `CHANGELOG.rst` from the tag history (dates from tags, contributors from git authors, summary from the msg/srv diff; `--check`/`--in-place`).
- `scripts/generate_release_notes.sh` — per-release notes from the message/service diff (added/removed/changed with field-level detail); wired into the release workflow.
- `QUALITY_DECLARATION.md` (REP-2004, Quality Level 3).

## Community health
- `CODE_OF_CONDUCT.md`, `SECURITY.md`, GitHub issue forms + PR template, `CODEOWNERS`; refreshed `README.md` and `CONTRIBUTING.md`.

## Debian packaging (continued from #65)
- Builder container parametrized by `ROS_DISTRO`, `bloom-generate rosdebian` + `rosdep install`, dropped the unneeded `rmw_zenoh_cpp` dep, CI-friendly (no interactive `-it`).
- `Package (.deb)` workflow builds `.deb`s for every supported distro on `amd64` + `arm64` and attaches them to releases.

## Release automation (full pipeline)
- `Create GitHub release`: publishes a release from upstream PX4 version bumps (`vX.Y.Z` tag or `release/**` bump), with notes from the message diff.
- The published release cascades into `Package (.deb)` and `Release to rosdistro (bloom)` (opens the `ros/rosdistro` PR via `bloom-release`).
- One-time maintainer setup (release repo + `BLOOM_GITHUB_TOKEN` / `RELEASE_TOKEN` secrets) is documented in `CONTRIBUTING.md`; workflows no-op gracefully until configured.

## CI matrix
Standard ROS build-farm tooling (`ros-tooling/setup-ros` + `action-ros-ci`), off the EOL Foxy/Focal jobs:
- **Ubuntu**: Humble, Jazzy, Kilted, Rolling. `setup-ros`/`action-ros-ci` are wrapped with retries (3 attempts) plus an apt-lock prep step, so transient infra failures (ros-apt-source GitHub-API 404s, apt mirror hiccups, randomly incomplete installs) self-heal instead of needing manual re-runs.
- **Windows**: Jazzy (Python 3.11). Not retry-wrapped — `wretry` injects the GitHub context as an env var that exceeds the Windows length limit and breaks `setup-ros`. Humble/Rolling aren't built on Windows (their binaries need Python 3.8/3.12, incompatible with the 3.11 ros-tooling requires).
- **macOS**: Jazzy on Apple Silicon + Intel via RoboStack/conda-forge (ROS 2 no longer ships macOS binaries). `ament_xmllint` is skipped there (conda-forge libxml2 has no HTTP support to fetch the schema; it still runs on Ubuntu).
- Rolling is Ubuntu-only (no Windows/macOS ROS 2 packaging channel). Push/pull_request runs are deduplicated.

## Linting (pre-commit)
A `pre-commit` job + `.pre-commit-config.yaml` covering: whitespace/EOL hygiene, shebang & executable-bit checks, XML/YAML/JSON syntax, GitHub Actions + Dependabot schema validation, `shellcheck`, `codespell`, `markdownlint`, and a **build-farm gate that validates `package.xml` with `catkin_pkg`** (the parser bloom uses) so a manifest that would fail to release is caught locally.

## Related work
- Continues / supersedes #65.
- GitHub Releases `v1.15.0`…`v1.17.0` were created (previously only tags existed), each with a detailed message-definition changelog.

## Type of change
- [x] Build / CI / packaging change
- [x] Documentation update

## Checklist
- [x] My changes do not edit the auto-generated `*.msg` / `*.srv` definitions.
- [x] I have read the CONTRIBUTING guide.
- [x] I have updated the `CHANGELOG.rst`.
- [x] `actionlint` + `pre-commit` pass locally; `package.xml` validates with `catkin_pkg` and the format-3 XSD.
- [x] CI builds/tests on Ubuntu (Humble/Jazzy/Kilted/Rolling), Windows (Jazzy), macOS (Jazzy, arm64 + Intel).
- [x] Commits are signed off (DCO) and follow Conventional Commits.
